### PR TITLE
Add optional temperature icons in graphics view

### DIFF
--- a/MMM-Teslamate.js
+++ b/MMM-Teslamate.js
@@ -22,6 +22,7 @@ Module.register("MMM-Teslamate", {
       batWidth: 250,
       betHeight: 75,
     },
+    showTemps: "hvac_on",
   },
 
   makeServerKey: function (server) {
@@ -381,6 +382,15 @@ Module.register("MMM-Teslamate", {
     const batteryBigNumber = this.config.rangeDisplay === "%" ? batteryUsable : idealRange;
     const batteryUnit = this.config.rangeDisplay === "%" ? "%" : (this.config.imperial ? "mi" : "km");
 
+    const showTemps = ((this.config.showTemps === "always") || 
+                       (this.config.showTemps === "hvac_on" && (isClimateOn == "true" || isPreconditioning == "true"))) &&
+                      (inside_temp && outside_temp);
+    const temperatureIcons = !showTemps ? "" :
+      `<span class="mdi mdi-car normal small"></span>
+       <span class="bright light small">${inside_temp}°</span>
+       &nbsp;&nbsp;
+       <span class="mdi mdi-earth normal small"></span>
+       <span class="bright light small">${outside_temp}°</span>`;
 
     wrapper.innerHTML = `
       <div style="width: ${layWidth}px; height: ${layHeight}px;">
@@ -485,7 +495,16 @@ Module.register("MMM-Teslamate", {
                           z-index: 5">
                 ${batteryOverlayIcon}
               </div>
+
             </div>
+          </div>
+
+          <!-- Optional graphic mode icons below the car -->
+          <div style="text-align: center; 
+                      margin-top: -10px; 
+                      ${temperatureIcons == "" ? 'display: none;' : ''}
+                      ${state == "offline" || state == "asleep" || state == "suspended" ? 'opacity: 0.3;' : ''}">
+            ${temperatureIcons}
           </div>
         </div>
       </div>

--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ Then run `npm install` inside the new cloned folder, and make sure to add the mo
             verticalOffset: 0,
 
             opacity: 0.5
-        }
+        },
+
+        // show inside and outside temperatures below the car image: when AC or preconditioning is running (default), always, or never
+        showTemps: "hvac_on", // "always", "never"
     }
 },
 ```


### PR DESCRIPTION
Wanted to keep closer tabs on how cold my car gets while sitting in the garage, and how quickly it heats up during preconditioning. Data was already there and even pre-formatted for metric or imperial, so I just added an option to show two icons and values below the car: either always, never, or only when AC or preconditioning is running (default).

![photo_2021-02-19_17-34-33](https://user-images.githubusercontent.com/650941/108533687-8df44e00-72d9-11eb-84dc-80b44c531edf.jpg)

Icons are greyed out when the car is offline or asleep to signify that the data is not up-to-date, same as the top left status icons.